### PR TITLE
Adding support for ROS2 Path messages

### DIFF
--- a/ros2_to_mass_amr_interop/__init__.py
+++ b/ros2_to_mass_amr_interop/__init__.py
@@ -28,7 +28,7 @@ from .messages import StatusReport
 
 
 def timestamp_to_isoformat(timestamp):
-    return datetime.utcfromtimestamp(timestamp).replace(microsecond=0).isoformat()
+    return datetime.fromtimestamp(timestamp).replace(microsecond=0).astimezone().isoformat()
 
 class MassAMRInteropNode(Node):
     """

--- a/ros2_to_mass_amr_interop/messages/__init__.py
+++ b/ros2_to_mass_amr_interop/messages/__init__.py
@@ -39,8 +39,8 @@ class MassObject:
     def _update_timestamp(self):
         # As per Mass example, data format is ISO8601
         # with timezone offset e.g. 2012-04-21T18:25:43-05:00
-        self.data[MASS_REPORT_TIMESTAMP] = datetime.utcnow() \
-            .replace(microsecond=0).isoformat()
+        self.data[MASS_REPORT_TIMESTAMP] = datetime.now() \
+            .replace(microsecond=0).astimezone().isoformat()
 
     def update_parameter(self, name, value):
         """


### PR DESCRIPTION
# Changes

Added support for ROS `nav_msgs/msg/Path` messages

# Demo

Sample message reported as valid by reference MassRobotics AMR receiver, including `path` and `destinations` fields (see sample test messages at `test/README.md`)

```
Status:
VALID
Message:
{
  "uuid": "foobar12345",
  "timestamp": "2021-06-18T09:40:29-03:00",
  "operationalState": "idle",
  "location": {
    "x": 0,
    "y": 0,
    "angle": {
      "w": 0,
      "x": 0,
      "y": 0,
      "z": 0
    },
    "planarDatum": "00000000-0000-0000-0000-000000000000"
  },
  "destinations": [
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 2,
      "y": 0,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 0,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 2,
      "y": 1,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 0,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 3,
      "y": 1,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 0,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 2,
      "y": 4,
      "z": 0,
      "angle": {
        "x": 1,
        "y": 1,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 2,
      "y": 6,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 2,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 6.2,
      "y": 2,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 2,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 11,
      "y": 0,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 4,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 9,
      "y": 5,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 1,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 6,
      "y": 3.1,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 2,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 1,
      "y": 1,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 0,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    }
  ],
  "path": [
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 2,
      "y": 0,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 0,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 2,
      "y": 1,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 0,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 3,
      "y": 1,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 0,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 2,
      "y": 4,
      "z": 0,
      "angle": {
        "x": 1,
        "y": 1,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 2,
      "y": 6,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 2,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 6.2,
      "y": 2,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 2,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 11,
      "y": 0,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 4,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 9,
      "y": 5,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 1,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 6,
      "y": 3.1,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 2,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    },
    {
      "timestamp": "1969-12-31T21:00:00-03:00",
      "x": 1,
      "y": 1,
      "z": 0,
      "angle": {
        "x": 0,
        "y": 0,
        "z": 1.8,
        "w": 1
      },
      "planarDatum": "096522ad-61fa-4796-9b31-e35b0f8d0b26"
    }
  ]
}
```