### PR TITLE
Fixes broken unit tests

### DIFF
--- a/massrobotics_amr_sender_py/launch/massrobotics_amr_sender.launch.py
+++ b/massrobotics_amr_sender_py/launch/massrobotics_amr_sender.launch.py
@@ -31,10 +31,10 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PathJoinSubstitution
-from launch.substitutions import ThisLaunchFileDir
 from launch_ros.actions import Node
 
 from ament_index_python.packages import get_package_share_directory
+
 
 def generate_launch_description():
     my_package_share_dir = get_package_share_directory('massrobotics_amr_sender')
@@ -42,7 +42,9 @@ def generate_launch_description():
     return LaunchDescription([
         DeclareLaunchArgument(
             'config_file',
-            default_value=PathJoinSubstitution([my_package_share_dir, 'params', 'sample_config.yaml']),
+            default_value=PathJoinSubstitution([
+                my_package_share_dir, 'params', 'sample_config.yaml'
+            ]),
             description='massrobotics_amr_sender node configuration file'
         ),
         Node(

--- a/massrobotics_amr_sender_py/massrobotics_amr_sender/__init__.py
+++ b/massrobotics_amr_sender_py/massrobotics_amr_sender/__init__.py
@@ -92,7 +92,7 @@ class MassRoboticsAMRInteropNode(Node):
         # Declare Node configuration parameter. Defaults to './config.yaml' if no
         # ``config_file`` parameter is provided. Provide the parameter when running
         # the node by using ``--ros-args -p config_file:=/path/to/config.yaml``
-        self.declare_parameter('config_file', 'config.yaml')
+        self.declare_parameter('config_file', 'params/config.yaml')
         config_file_param = self.get_parameter(name='config_file')
         config_file_path = config_file_param.get_parameter_value().string_value
         self._config = self._read_config_file(config_file_path=config_file_path)

--- a/massrobotics_amr_sender_py/test/test_mass_interop.py
+++ b/massrobotics_amr_sender_py/test/test_mass_interop.py
@@ -43,7 +43,7 @@ from nav_msgs import msg as ros_nav_msgs
 from builtin_interfaces import msg as ros_builtin_msgs
 
 cwd = Path(__file__).resolve().parent
-config_file_test = Path(cwd).parent / "sample_config.yaml"
+config_file_test = Path(cwd).parent / "params" / "sample_config.yaml"
 
 FAKE_ROBOT_ID = 'd6f7c89c-6b11-45b4-b763-86cec88cc2eb'
 

--- a/massrobotics_amr_sender_py/test/test_mass_interop_config.py
+++ b/massrobotics_amr_sender_py/test/test_mass_interop_config.py
@@ -38,7 +38,7 @@ cwd = Path(__file__).resolve().parent
 
 
 def test_mass_config_load():
-    cfg_file_path = Path(cwd).parent / "sample_config.yaml"
+    cfg_file_path = Path(cwd).parent / "params" / "sample_config.yaml"
     assert MassRoboticsAMRInteropConfig(str(cfg_file_path)).mappings != {}
 
 
@@ -50,7 +50,7 @@ def test_mass_config_load():
     ("maxSpeed", CFG_PARAMETER_LOCAL)
 ])
 def test_mass_config_get_parameter_type(param_name, param_type):
-    cfg_file_path = Path(cwd).parent / "sample_config.yaml"
+    cfg_file_path = Path(cwd).parent / "params" / "sample_config.yaml"
     mass_config = MassRoboticsAMRInteropConfig(str(cfg_file_path))
     assert mass_config.get_parameter_source(param_name) == param_type
 
@@ -63,7 +63,7 @@ def test_mass_config_get_parameter_type(param_name, param_type):
 ])
 def test_mass_config_get_parameter_value(monkeypatch, param_name, value):
     monkeypatch.setenv("MY_UUID", "foo")  # Environment variable used on config file
-    cfg_file_path = Path(cwd).parent / "sample_config.yaml"
+    cfg_file_path = Path(cwd).parent / "params" / "sample_config.yaml"
     mass_config = MassRoboticsAMRInteropConfig(str(cfg_file_path))
     assert mass_config.get_parameter_value(param_name) == value
 
@@ -77,6 +77,6 @@ def test_mass_config_get_parameter_value(monkeypatch, param_name, value):
 ])
 def test_mass_config_get_parameters_by_source(monkeypatch, param_name, source):
     monkeypatch.setenv("MY_UUID", "foo")  # Environment variable used on config file
-    cfg_file_path = Path(cwd).parent / "sample_config.yaml"
+    cfg_file_path = Path(cwd).parent / "params" / "sample_config.yaml"
     mass_config = MassRoboticsAMRInteropConfig(str(cfg_file_path))
     assert param_name in mass_config.parameters_by_source[source]


### PR DESCRIPTION
Fixes unit tests broken in the previous PR #20 . Now I learned to run tests before submitting PRs.

Now it runs like so:

```
docker@foxy-645:~/dev/temp/catkin_ws$ colcon build --packages-select massrobotics_amr_sender
Starting >>> massrobotics_amr_sender
Finished <<< massrobotics_amr_sender [0.63s]          

Summary: 1 package finished [0.74s]
docker@foxy-645:~/dev/temp/catkin_ws$ colcon test --packages-select massrobotics_amr_sender
Starting >>> massrobotics_amr_sender
--- stderr: massrobotics_amr_sender                   

=============================== warnings summary ===============================
/usr/lib/python3/dist-packages/pydocstyle/config.py:6
  Warning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working

-- Docs: https://docs.pytest.org/en/latest/warnings.html
---
Finished <<< massrobotics_amr_sender [3.33s]

Summary: 1 package finished [3.50s]
  1 package had stderr output: massrobotics_amr_sender
docker@foxy-645:~/dev/temp/catkin_ws$ colcon test-result --verbose
Summary: 22 tests, 0 errors, 0 failures, 0 skipped
docker@foxy-645:~/dev/temp/catkin_ws$ 

```