### PR TITLE
Add github action for running pre-commit

### DIFF
--- a/.github/workflows/code-quality.yaml
+++ b/.github/workflows/code-quality.yaml
@@ -1,0 +1,15 @@
+name: Code quality
+
+on:
+  pull_request:
+  push:
+    branches: [foxy-devel]
+
+jobs:
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,6 @@ repos:
       - id: check-json
 
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 21.7b0
     hooks:
       - id: black


### PR DESCRIPTION
Adds a github action to run pre-commit checks on PRs and on the main branch. You could mark this check as required in the repo settings.

It also updates black to the latest version.