### PR TITLE
(O-RMF Adapter) Fix duplicated API calls

### DIFF
--- a/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
@@ -472,7 +472,6 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         # waypoints with a 30" timestamp difference.
         # The following lines filter the first waypoint of these pairs to prevent an excess of 
         # navigation requests from the fleet adapter
-        # More information in this issue: https://github.com/inorbit-ai/ros_amr_interop/pull/41
         for i in range(1, len(waypoints)):
             if (waypoints[i-1].position == waypoints[i].position).all():
                 self.node.get_logger().info(f"Found duplicated consecutive waypoints in waypoints list: {waypoints[i].position}; {waypoints[i].time}, {waypoints[i-1].time}")

--- a/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
@@ -182,7 +182,8 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
             next_arrival_estimator,
             path_finished_callback):
 
-        self.stop()
+        if self.state.MOVING:
+            self.stop()
         self._quit_path_event.clear()
 
         self.node.get_logger().info(
@@ -196,6 +197,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
 
         def _follow_path():
             target_pose = []
+            sleep_time = 0.1
             while (
                     self.remaining_waypoints or
                     self.state == RobotState.MOVING or
@@ -221,12 +223,12 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                     else:
                         self.node.get_logger().info(
                             f"Robot {self.robot.name} failed to navigate to "
-                            f"[{x:.0f}, {y:.0f}, {theta:.0f}] coordinates. "
+                            f"[{x:.2f}, {y:.2f}, {theta:.2f}] coordinates. "
                             f"Retrying...")
-                        self.sleep_for(0.1)
+                        self.sleep_for(sleep_time)
 
                 elif self.state == RobotState.WAITING:
-                    self.sleep_for(0.1)
+                    self.sleep_for(sleep_time)
                     time_now = self.adapter.now()
                     with self._lock:
                         if self.target_waypoint is not None:
@@ -239,7 +241,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                                         self.path_index, timedelta(seconds=0.0))
 
                 elif self.state == RobotState.MOVING:
-                    self.sleep_for(0.1)
+                    self.sleep_for(sleep_time)
                     # Check if we have reached the target
                     with self._lock:
                         if (self.robot.navigation_completed()):

--- a/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
@@ -469,7 +469,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         assert (len(waypoints) > 0)
 
         # When the "responsive wait" feature is enabled, RMF will send two consecutive identical 
-        # waypoints with a 30" timestamp difference with the same position.
+        # waypoints with a 30" timestamp difference.
         # The following lines filter the first waypoint of these pairs to prevent an excess of 
         # navigation requests from the fleet adapter
         # More information in this issue: https://github.com/inorbit-ai/ros_amr_interop/pull/41

--- a/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
@@ -472,13 +472,11 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         # waypoints with a 30" timestamp difference.
         # The following lines filter the first waypoint of these pairs to prevent an excess of
         # navigation requests from the fleet adapter
+        final_waypoints = [waypoints[0]]
         for i in range(1, len(waypoints)):
             if (waypoints[i-1].position == waypoints[i].position).all():
                 self.node.get_logger().info(f"Found duplicated consecutive waypoints in waypoints list: {waypoints[i].position}; {waypoints[i].time}, {waypoints[i-1].time}")
-                waypoints.pop(i)
-                i -= 1
+            else:
+                final_waypoints.append(waypoints[i])
 
-        remaining_waypoints = []
-        for i in range(len(waypoints)):
-            remaining_waypoints.append((i, waypoints[i]))
-        return remaining_waypoints
+        return list(enumerate(final_waypoints))

--- a/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
@@ -247,7 +247,7 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
                         if (self.robot.navigation_completed()):
                             self.node.get_logger().info(
                                 f"Robot [{self.robot.name}] has reached its target "
-                                f"waypoint")
+                                f"waypoint {self.target_waypoint.position}")
                             self.state = RobotState.WAITING
                             if (self.target_waypoint.graph_index is not None):
                                 self.on_waypoint = \
@@ -468,12 +468,13 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         '''
         assert (len(waypoints) > 0)
 
-        # Occasionally, RMF will send two consecutive waypoints with the same values in the `waypoints` argument
-        # of RobotCommandHandle::follow_new_path(), causing an excess of navigation requests from the fleet adapter
+        # Occasionally, RMF will send two consecutive waypoints with the same position 
+        # and time values in the `waypoints` argument of RobotCommandHandle::follow_new_path(),
+        # causing an excess of navigation requests from the fleet adapter
         # The following lines will filter them out
         for i in range(1, len(waypoints)):
-            self.node.get_logger().info("Found duplicated consecutive waypoints in waypoints list")
-            if (waypoints[i-1].position == waypoints[i].position).all():
+            if (waypoints[i-1].position == waypoints[i].position).all() and (waypoints[i-1].time == waypoints[i].time):
+                self.node.get_logger().info(f"Found duplicated consecutive waypoints in waypoints list: {waypoints[i].position} {waypoints[i].time}, {waypoints[i-1].time}")
                 waypoints.pop(i)
                 i -= 1
 

--- a/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
@@ -467,8 +467,17 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         may be modified if waypoints in a path need to be filtered.
         '''
         assert (len(waypoints) > 0)
-        remaining_waypoints = []
 
+        # Occasionally, RMF will send two consecutive waypoints with the same values in the `waypoints` argument
+        # of RobotCommandHandle::follow_new_path(), causing an excess of navigation requests from the fleet adapter
+        # The following lines will filter them out
+        for i in range(1, len(waypoints)):
+            self.node.get_logger().info("Found duplicated consecutive waypoints in waypoints list")
+            if (waypoints[i-1].position == waypoints[i].position).all():
+                waypoints.pop(i)
+                i -= 1
+
+        remaining_waypoints = []
         for i in range(len(waypoints)):
             remaining_waypoints.append((i, waypoints[i]))
         return remaining_waypoints

--- a/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
@@ -468,13 +468,14 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         '''
         assert (len(waypoints) > 0)
 
-        # Occasionally, RMF will send two consecutive waypoints with the same position 
-        # and time values in the `waypoints` argument of RobotCommandHandle::follow_new_path(),
-        # causing an excess of navigation requests from the fleet adapter
-        # The following lines will filter them out
+        # When the "responsive wait" feature is enabled, RMF will send two consecutive identical 
+        # waypoints with a 30" timestamp difference with the same position.
+        # The following lines filter the first waypoint of these pairs to prevent an excess of 
+        # navigation requests from the fleet adapter
+        # More information in this issue: https://github.com/inorbit-ai/ros_amr_interop/pull/41
         for i in range(1, len(waypoints)):
-            if (waypoints[i-1].position == waypoints[i].position).all() and (waypoints[i-1].time == waypoints[i].time):
-                self.node.get_logger().info(f"Found duplicated consecutive waypoints in waypoints list: {waypoints[i].position} {waypoints[i].time}, {waypoints[i-1].time}")
+            if (waypoints[i-1].position == waypoints[i].position).all():
+                self.node.get_logger().info(f"Found duplicated consecutive waypoints in waypoints list: {waypoints[i].position}; {waypoints[i].time}, {waypoints[i-1].time}")
                 waypoints.pop(i)
                 i -= 1
 

--- a/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
+++ b/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py
@@ -468,9 +468,9 @@ class RobotCommandHandle(adpt.RobotCommandHandle):
         '''
         assert (len(waypoints) > 0)
 
-        # When the "responsive wait" feature is enabled, RMF will send two consecutive identical 
+        # When the "responsive wait" feature is enabled, RMF will send two consecutive identical
         # waypoints with a 30" timestamp difference.
-        # The following lines filter the first waypoint of these pairs to prevent an excess of 
+        # The following lines filter the first waypoint of these pairs to prevent an excess of
         # navigation requests from the fleet adapter
         for i in range(1, len(waypoints)):
             if (waypoints[i-1].position == waypoints[i].position).all():


### PR DESCRIPTION
Two issues were recently found when utilizing the adapter:
* Duplicated stop calls
  * Fix on [this line](https://github.com/inorbit-ai/ros_amr_interop/blob/ac42816d9ab9fa004d9963c9c5565812be6b2039/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py#L185). Every time a new path was received, a new .stop() call was made. Very often new paths are received right after finishing the last one, causing duplicated stop calls
* Duplicated waypoint navigation calls
  * When the "responsive wait" feature is enabled, RMF will send two consecutive identical waypoints with a 30" timestamp difference in the `waypoints` argument of `RobotCommandHandle.follow_new_path()`, causing an excess of navigation requests from the fleet adapter (one call at t=0, one at t=30, and then again at t=30 and t=60, etc.). [These lines](https://github.com/inorbit-ai/ros_amr_interop/blob/ac42816d9ab9fa004d9963c9c5565812be6b2039/rmf_inorbit_fleet_adapter/rmf_inorbit_fleet_adapter/RobotCommandHandle.py#L474) filter these points out.