### PR TITLE
Fix/correct keyword  state topic information

### DIFF
--- a/vda5050_connector/include/vda5050_connector/handler.hpp
+++ b/vda5050_connector/include/vda5050_connector/handler.hpp
@@ -97,13 +97,13 @@ public:
   }
 
   /**
-   * @brief Add a new information msg into the informations array of the order state
+   * @brief Add a new information msg into the information array of the order state
    * Only one thread/writer can modify the order_state.
    */
   void add_information(const vda5050_msgs::msg::Info & info)
   {
     std::unique_lock lock(mutex);
-    order_state_.informations.push_back(info);
+    order_state_.information.push_back(info);
   }
 
   /**
@@ -127,14 +127,14 @@ public:
   }
 
   /**
-   * @brief Clear the order state arrays (load, informations and errors).
+   * @brief Clear the order state arrays (load, information and errors).
    * Only one thread/writer can clear the order_state.
    */
   void clear()
   {
     std::unique_lock lock(mutex);
     order_state_.loads.clear();
-    order_state_.informations.clear();
+    order_state_.information.clear();
     order_state_.errors.clear();
   }
 

--- a/vda5050_connector/test/adapter/handler_execution/handler_execution_test.cpp
+++ b/vda5050_connector/test/adapter/handler_execution/handler_execution_test.cpp
@@ -72,14 +72,14 @@ TEST_F(AdapterTest, HandlerExecution)
 
   // Check handlers could modify global current state on configure
   auto order_state = adapter_node->get_current_state();
-  EXPECT_EQ(static_cast<int>(order_state.informations.size()), 1);
+  EXPECT_EQ(static_cast<int>(order_state.information.size()), 1);
   EXPECT_FLOAT_EQ(static_cast<int>(order_state.battery_state.battery_charge), 100.0);
 
   // Check handlers could modify global current state on execute
   ASSERT_NO_THROW(adapter_node->call_update_current_state());
   order_state = adapter_node->get_current_state();
-  // Update current state should clear previous loads, error and informations
-  EXPECT_EQ(static_cast<int>(order_state.informations.size()), 1);
+  // Update current state should clear previous loads, error and information
+  EXPECT_EQ(static_cast<int>(order_state.information.size()), 1);
   EXPECT_FLOAT_EQ(static_cast<int>(order_state.battery_state.battery_charge), 90.0);
 
   // Test vda action execute state machine: Transitions and call of state funcs

--- a/vda5050_connector/test/adapter/plugin_load/plugin_load_test.cpp
+++ b/vda5050_connector/test/adapter/plugin_load/plugin_load_test.cpp
@@ -105,7 +105,7 @@ TEST_F(AdapterTest, HandlerLoadHandlers)
 
   // Check handlers could modify global current state on configure
   auto order_state = adapter_node->get_current_state();
-  EXPECT_EQ(static_cast<int>(order_state.informations.size()), 1);
+  EXPECT_EQ(static_cast<int>(order_state.information.size()), 1);
   EXPECT_FLOAT_EQ(order_state.distance_since_last_node, 10.0);
   EXPECT_EQ(order_state.paused, true);
 

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -665,7 +665,7 @@ class VDA5050Controller(Node):
                 "distance_since_last_node": order_state.state.distance_since_last_node,
                 "battery_state": order_state.state.battery_state,
                 "errors": current_errors + order_state.state.errors,
-                "informations": order_state.state.informations
+                "information": order_state.state.information
             }
         )
 

--- a/vda5050_msgs/msg/OrderState.msg
+++ b/vda5050_msgs/msg/OrderState.msg
@@ -65,7 +65,7 @@ string operating_mode                                # Enum {AUTOMATIC, SEMIAUTO
 
 vda5050_msgs/Error[] errors                          # Array of errorobjects. Empty array if there are no errors.
 
-vda5050_msgs/Info[] informations                     # Array of info-objects. An empty array indicates that the AGV has no information.
+vda5050_msgs/Info[] information                      # Array of info-objects. An empty array indicates that the AGV has no information.
                                                      # This should only be used for visualization or debugging – it must not be used for logic in master control
 
 vda5050_msgs/SafetyState safety_state                # Contains all safetyrelated information.


### PR DESCRIPTION
State message include information part and this key name is not correct in the script 
Correct name of the key is not **informations** it is **information** 
 
![image](https://github.com/inorbit-ai/ros_amr_interop/assets/26343575/e1ba3ad6-fad4-407b-bb63-9a5ebed836c9)
