### PR TITLE
Fix/object-key-convention

### DIFF
--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -1171,8 +1171,8 @@ class VDA5050Controller(Node):
         # Only on stitching updates the node and edges base states are kept
         self._update_state(
             {
-                "order_id": order.order_id,
-                "order_update_id": order.order_update_id,
+                "orderId": order.order_id,
+                "orderUpdateId": order.order_update_id,
                 "errors": errors,
                 "node_states": (mode == OrderAcceptModes.STITCH) * self._current_state.node_states
                 + self._get_node_states(order),
@@ -1208,19 +1208,18 @@ class VDA5050Controller(Node):
         if error == OrderRejectErrors.ORDER_UPDATE_ERROR:
             # On orderUpdateError send orderUpdateId and orderId as reference
 
-            # TODO: Question: camelCase or snakeCase (order_id or orderId)
             error_references.append(
-                VDAErrorReference(reference_key="order_id", reference_value=order.order_id)
+                VDAErrorReference(reference_key="orderId", reference_value=order.order_id)
             )
             error_references.append(
                 VDAErrorReference(
-                    reference_key="order_update_id", reference_value=str(order.order_update_id)
+                    reference_key="orderUpdateId", reference_value=str(order.order_update_id)
                 )
             )
         elif error == OrderRejectErrors.NO_ROUTE_ERROR:
             # On noRouteError send 1st node as reference
             error_references.append(
-                VDAErrorReference(reference_key="node_id", reference_value=order.nodes[0].node_id)
+                VDAErrorReference(reference_key="nodeId", reference_value=order.nodes[0].node_id)
             )
 
         order_error = VDAError()

--- a/vda5050_msgs/msg/OrderState.msg
+++ b/vda5050_msgs/msg/OrderState.msg
@@ -65,7 +65,7 @@ string operating_mode                                # Enum {AUTOMATIC, SEMIAUTO
 
 vda5050_msgs/Error[] errors                          # Array of errorobjects. Empty array if there are no errors.
 
-vda5050_msgs/Info[] information                      # Array of info-objects. An empty array indicates that the AGV has no information.
+vda5050_msgs/Info[] informations                     # Array of info-objects. An empty array indicates that the AGV has no information.
                                                      # This should only be used for visualization or debugging – it must not be used for logic in master control
 
 vda5050_msgs/SafetyState safety_state                # Contains all safetyrelated information.

--- a/vda5050_msgs/msg/OrderState.msg
+++ b/vda5050_msgs/msg/OrderState.msg
@@ -65,7 +65,7 @@ string operating_mode                                # Enum {AUTOMATIC, SEMIAUTO
 
 vda5050_msgs/Error[] errors                          # Array of errorobjects. Empty array if there are no errors.
 
-vda5050_msgs/Info[] informations                     # Array of info-objects. An empty array indicates that the AGV has no information.
+vda5050_msgs/Info[] information                      # Array of info-objects. An empty array indicates that the AGV has no information.
                                                      # This should only be used for visualization or debugging – it must not be used for logic in master control
 
 vda5050_msgs/SafetyState safety_state                # Contains all safetyrelated information.


### PR DESCRIPTION
As mentioned in the issue ticket, object key conversions have been changed to camelCase as stated in the documentation.
https://github.com/inorbit-ai/ros_amr_interop/issues/48