### PR TITLE
Fix: mqtt_client.Client() missing 1 required argument callback_api_version

### DIFF
--- a/vda5050_connector/vda5050_connector_py/mqtt_bridge.py
+++ b/vda5050_connector/vda5050_connector_py/mqtt_bridge.py
@@ -34,6 +34,7 @@
 # Python dependencies
 from paho.mqtt import client as mqtt_client
 from paho.mqtt.client import error_string
+from paho.mqtt.enums import CallbackAPIVersion
 import copy
 import json
 import ssl
@@ -215,7 +216,7 @@ class MQTTBridge(Node):
         self._serial_number = read_str_parameter(self, "serial_number", "robot_1")
 
         # Configure MQTT
-        self.mqtt_client = mqtt_client.Client()
+        self.mqtt_client = mqtt_client.Client(CallbackAPIVersion.VERSION1)
         self.mqtt_client.on_connect = self.on_connect_mqtt
         self.mqtt_client.on_message = self.on_message_mqtt
         self.mqtt_client.on_disconnect = self.on_disconnect_mqtt


### PR DESCRIPTION
Before fix, 
```bash
$ ros2 launch vda5050_connector mqtt_bridge.launch.py 
[INFO] [launch]: All log files can be found below /home/damon/.ros/log/2024-02-17-22-52-36-339557-damon-lenovo-46076
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [mqtt_bridge.py-1]: process started with pid [46088]
[mqtt_bridge.py-1] Exception ignored in: <function Client.__del__ at 0x7f14f25f1c60>
[mqtt_bridge.py-1] Traceback (most recent call last):
[mqtt_bridge.py-1]   File "/home/damon/.local/lib/python3.10/site-packages/paho/mqtt/client.py", line 874, in __del__
[mqtt_bridge.py-1]     self._reset_sockets()
[mqtt_bridge.py-1]   File "/home/damon/.local/lib/python3.10/site-packages/paho/mqtt/client.py", line 1133, in _reset_sockets
[mqtt_bridge.py-1]     self._sock_close()
[mqtt_bridge.py-1]   File "/home/damon/.local/lib/python3.10/site-packages/paho/mqtt/client.py", line 1119, in _sock_close
[mqtt_bridge.py-1]     if not self._sock:
[mqtt_bridge.py-1] AttributeError: 'Client' object has no attribute '_sock'
[mqtt_bridge.py-1] Traceback (most recent call last):
[mqtt_bridge.py-1]   File "/home/damon/colcon_ws/install/vda5050_connector/lib/vda5050_connector/mqtt_bridge.py", line 58, in <module>
[mqtt_bridge.py-1]     main()
[mqtt_bridge.py-1]   File "/home/damon/colcon_ws/install/vda5050_connector/lib/vda5050_connector/mqtt_bridge.py", line 41, in main
[mqtt_bridge.py-1]     mqtt_bridge = MQTTBridge()
[mqtt_bridge.py-1]   File "/home/damon/colcon_ws/install/vda5050_connector/local/lib/python3.10/dist-packages/vda5050_connector_py/mqtt_bridge.py", line 220, in __init__
[mqtt_bridge.py-1]     self.mqtt_client = mqtt_client.Client()
[mqtt_bridge.py-1] TypeError: Client.__init__() missing 1 required positional argument: 'callback_api_version'
[ERROR] [mqtt_bridge.py-1]: process has died [pid 46088, exit code 1, cmd '/home/damon/colcon_ws/install/vda5050_connector/lib/vda5050_connector/mqtt_bridge.py --ros-args -r __node:=mqtt_bridge -r __ns:=/vda5050 --params-file /tmp/tmpdpdr7fj5'].
```
After fix, 
```bash
$ ros2 launch vda5050_connector mqtt_bridge.launch.py 
[INFO] [launch]: All log files can be found below /home/damon/.ros/log/2024-02-17-23-19-26-460626-damon-lenovo-83003
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [mqtt_bridge.py-1]: process started with pid [83005]
[mqtt_bridge.py-1] [INFO] [1708183166.755924519] [vda5050.mqtt_bridge]: Configuring ROS topics
[mqtt_bridge.py-1] [INFO] [1708183166.763722569] [vda5050.mqtt_bridge]: Connected to MQTT Broker!
[mqtt_bridge.py-1] [INFO] [1708183166.763942836] [vda5050.mqtt_bridge]: Finished configuring ROS topics
[mqtt_bridge.py-1] [INFO] [1708183166.764657397] [vda5050.mqtt_bridge]: Node mqtt_bridge has started successfully.
```