### PR TITLE
Check if AGV failed to reach goal

### DIFF
--- a/vda5050_connector/vda5050_connector_py/mqtt_bridge.py
+++ b/vda5050_connector/vda5050_connector_py/mqtt_bridge.py
@@ -243,6 +243,8 @@ class MQTTBridge(Node):
         )
         self._serial_number = read_str_parameter(self, "serial_number", "robot_1")
 
+        self._interface_name = read_str_parameter(self, "interface_name", "uagv")
+
         # Configure MQTT
         self.mqtt_client = mqtt_client.Client()
         self.mqtt_client.on_connect = self.on_connect_mqtt
@@ -268,6 +270,7 @@ class MQTTBridge(Node):
             serial_number=self._serial_number,
             topic="connection",
             major_version=self.vda5050_version_alias,
+            interface_name=self._interface_name
         )
 
         # NOTE: will payload cannot be set dynamically or updated
@@ -309,6 +312,7 @@ class MQTTBridge(Node):
                     serial_number=self._serial_number,
                     topic="order",
                     major_version=self.vda5050_version_alias,
+                    interface_name=self._interface_name
                 )
             )
             self.mqtt_client.subscribe(
@@ -316,7 +320,8 @@ class MQTTBridge(Node):
                     manufacturer=self._manufacturer_name,
                     serial_number=self._serial_number,
                     topic="instantActions",
-                    major_version=self.vda5050_version_alias
+                    major_version=self.vda5050_version_alias,
+                    interface_name=self._interface_name
                 )
             )
             self._publish_connection(
@@ -383,6 +388,7 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="state",
+                interface_name=self._interface_name
             ),
             callback=self._publish_state,
             qos_profile=10,
@@ -394,6 +400,7 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="connection",
+                interface_name=self._interface_name
             ),
             callback=self._publish_connection,
             qos_profile=10,
@@ -405,6 +412,7 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="visualization",
+                interface_name=self._interface_name
             ),
             callback=self._publish_visualization,
             qos_profile=10,
@@ -416,6 +424,7 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="order",
+                interface_name=self._interface_name
             ),
             qos_profile=10,
         )
@@ -426,6 +435,7 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="instantActions",
+                interface_name=self._interface_name
             ),
             qos_profile=10,
         )
@@ -456,7 +466,8 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="order",
-                major_version=self.vda5050_version_alias
+                major_version=self.vda5050_version_alias,
+                interface_name=self._interface_name
             )
         )
         self.mqtt_client.unsubscribe(
@@ -464,7 +475,8 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="instantActions",
-                major_version=self.vda5050_version_alias
+                major_version=self.vda5050_version_alias,
+                interface_name=self._interface_name
             )
         )
 
@@ -497,7 +509,8 @@ class MQTTBridge(Node):
             manufacturer=self._manufacturer_name,
             serial_number=self._serial_number,
             topic="state",
-            major_version=self.vda5050_version_alias
+            major_version=self.vda5050_version_alias,
+            interface_name=self._interface_name
         )
         self._publish_to_topic(msg, topic)
 
@@ -520,7 +533,8 @@ class MQTTBridge(Node):
             manufacturer=self._manufacturer_name,
             serial_number=self._serial_number,
             topic="connection",
-            major_version=self.vda5050_version_alias
+            major_version=self.vda5050_version_alias,
+            interface_name=self._interface_name
         )
         self._publish_to_topic(msg, topic)
 
@@ -537,6 +551,7 @@ class MQTTBridge(Node):
             manufacturer=self._manufacturer_name,
             serial_number=self._serial_number,
             topic="visualization",
-            major_version=self.vda5050_version_alias
+            major_version=self.vda5050_version_alias,
+            interface_name=self._interface_name
         )
         self._publish_to_topic(msg, topic)

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -675,7 +675,8 @@ class VDA5050Controller(Node):
                 "distance_since_last_node": order_state.state.distance_since_last_node,
                 "battery_state": order_state.state.battery_state,
                 "errors": current_errors + order_state.state.errors,
-                "informations": order_state.state.informations
+                "informations": order_state.state.informations,
+                "operating_mode": order_state.state.operating_mode
             }
         )
 

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -96,6 +96,7 @@ DEFAULT_SERIAL_NUMBER = "robot_1"
 DEFAULT_PROTOCOL_VERSION = "2.0.0"
 DEFAULT_STARTING_NODE_ID = ""
 SUPPORTED_PROTOCOL_VERSIONS = ["1.1.0", "2.0.0"]
+DEFAULT_INTERFACE_NAME = "uagv"
 
 DEFAULT_GET_STATE_SVC_NAME = "adapter/get_state"
 DEFAULT_SUPPORTED_ACTIONS_SVC_NAME = "adapter/supported_actions"
@@ -228,6 +229,8 @@ class VDA5050Controller(Node):
         self._execute_order_period = read_double_parameter(
             self, "execute_order_period", DEFAULT_EXECUTE_ORDER_PERIOD
         )
+        self._interface_name = read_str_parameter(self, "interface_name", DEFAULT_INTERFACE_NAME)
+
 
     # ---- Configure ROS interfaces ----
 
@@ -292,6 +295,7 @@ class VDA5050Controller(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="order",
+                interface_name=self._interface_name
             ),
             callback=self.process_order,
             qos_profile=10,
@@ -304,6 +308,7 @@ class VDA5050Controller(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="instantActions",
+                interface_name=self._interface_name
             ),
             callback=self.process_instant_actions,
             qos_profile=10,
@@ -318,6 +323,7 @@ class VDA5050Controller(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="state",
+                interface_name=self._interface_name
             ),
             qos_profile=10,
         )
@@ -329,6 +335,7 @@ class VDA5050Controller(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="connection",
+                interface_name=self._interface_name
             ),
             qos_profile=10,
         )
@@ -340,6 +347,7 @@ class VDA5050Controller(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="visualization",
+                interface_name=self._interface_name
             ),
             qos_profile=10,
         )
@@ -351,6 +359,7 @@ class VDA5050Controller(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="factsheet",
+                interface_name=self._interface_name
             ),
             qos_profile=10,
         )

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -80,6 +80,7 @@ from vda5050_msgs.msg import Timing as VDATiming
 from vda5050_msgs.msg import TypeSpecification as VDATypeSpecification
 from vda5050_msgs.msg import Visualization as VDAVisualization
 from vda5050_msgs.msg import WheelDefinition as VDAWheelDefinition
+from action_msgs.msg import GoalStatus
 
 from vda5050_connector.srv import GetState
 from vda5050_connector.srv import SupportedActions
@@ -1522,11 +1523,31 @@ class VDA5050Controller(Node):
             future (Future): Action result future.
 
         """
-        # TODO: Check when the goal fails
         self._navigate_to_node_goal_handle = None
 
         # When the order is cancelled, this callback should avoid continuing its logic
         if self._canceling_order():
+            return
+
+        # Check if goal failed
+        status = future.result().status
+        if status == GoalStatus.STATUS_ABORTED:
+            self.logger.info("Failed to reach goal. Order aborted.")
+
+            # Notify master of the failure
+            error = VDAError()
+            error.error_type = OrderRejectErrors.NO_ROUTE_ERROR.value
+            error.error_description = "Failed to reach current node."
+            error.error_level = VDAError.FATAL
+            error.error_references = [
+                VDAErrorReference(
+                    reference_key="node_id", reference_value=self._current_node_goal.node_id
+                )
+            ]
+
+            current_errors = self._current_state.errors
+            self._update_state({"errors": current_errors + [error]}, publish_now=True)
+
             return
 
         last_edge = next(


### PR DESCRIPTION
This PR checks in `_navigate_to_node_result_callback` of the `vda5050_controller` if the NavToNode order sent to the adapter failed, as this was still marked as a to do in the code.

In addition to that, it fixes the problems mentioned in [issue 59](https://github.com/inorbit-ai/ros_amr_interop/issues/59): being able to update the robot's operating from the adapter and to configure the `interface_name`, used for ROS and MQTT topics creation, from the YAML configuration file.

