### PR TITLE
Orientation of the edge's trajectory control points in order message

### DIFF
--- a/vda5050_connector/vda5050_connector_py/mqtt_bridge.py
+++ b/vda5050_connector/vda5050_connector_py/mqtt_bridge.py
@@ -133,6 +133,7 @@ def generate_vda_order_msg(order):
                     VDAControlPoint(
                         x=float(cp["x"]),
                         y=float(cp["y"]),
+                        orientation=float(cp["orientation"]),
                         weight=float(cp.get("weight", 1)),
                     )
                     for cp in edge["trajectory"]["control_points"]


### PR DESCRIPTION
When converting the MQTT order message into a ROS message, the orientation field of the edge's trajectory control points is never retrieved from the MQTT message. So the ROS message always has a null orientation.