### PR TITLE
Stitching order: check last node of base instead of last node of entire order

### DIFF
--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -1032,7 +1032,10 @@ class VDA5050Controller(Node):
             True if last <> first base nodes match, False otherwise.
 
         """
-        last_node = self._current_order.nodes[-1]
+        base_order_nodes = [
+            node for node in self._current_order.nodes if node.released
+        ]
+        last_node = base_order_nodes[-1]
         stitch_node = order.nodes[0]
 
         # Return False if node actions differ

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -1035,6 +1035,9 @@ class VDA5050Controller(Node):
         base_order_nodes = [
             node for node in self._current_order.nodes if node.released
         ]
+        if not base_order_nodes:
+            self.logger.error("Error while validating stitch node: current order does not have any node.")
+            return False
         last_node = base_order_nodes[-1]
         stitch_node = order.nodes[0]
 


### PR DESCRIPTION
Fix for the issue https://github.com/inorbit-ai/ros_amr_interop/issues/58