### PR TITLE
vda5050_controller: create error entry in state if action fails

### DIFF
--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -114,6 +114,7 @@ class ActionErrors(Enum):
     """Action Error types."""
 
     ACTION_NOT_FOUND = "actionNotFound"
+    ACTION_FAILED = "actionFailed"
     NO_ORDER_TO_CANCEL = "noOrderToCancel"
 
 
@@ -556,7 +557,7 @@ class VDA5050Controller(Node):
         )
         return action_state.action_status
 
-    def _update_action_status(self, action_id: str, action_status: str):
+    def _update_action_status(self, action_id: str, action_status: str, result_description: str = ""):
         """
         Update action status on the current state given action's ID.
 
@@ -604,8 +605,10 @@ class VDA5050Controller(Node):
             self._update_state({"errors": current_errors})
             return
 
-        # If found, update action status
+        # If found, update action status and result description
         action_state.action_status = action_status
+        if action_status == VDACurrentAction.FINISHED:
+            action_state.result_description = result_description
 
     # ---- Adapter's state ----
 
@@ -642,7 +645,7 @@ class VDA5050Controller(Node):
 
         """
         if action:
-            self._update_action_status(action.action_id, VDACurrentAction.FINISHED)
+            self._update_action_status(action.action_id, VDACurrentAction.FINISHED, action.result_description)
         self._update_state_from_adapter(future.result())
         self._publish_state()
 
@@ -845,8 +848,22 @@ class VDA5050Controller(Node):
         action_result: ProcessVDAAction.Result = future.result().result
         current_action: VDACurrentAction = action_result.result
         self._process_vda_action_goal_handle_dict.pop(current_action.action_id)
-        self._update_action_status(current_action.action_id, current_action.action_status)
+        self._update_action_status(current_action.action_id, current_action.action_status, current_action.result_description)
         self.logger.info(f"VDA Action finished. Result: {current_action}")
+
+        # Create an error entry for failed action
+        if current_action.action_status == VDACurrentAction.FAILED:
+            error = VDAError(
+                error_type=ActionErrors.ACTION_FAILED.value,
+                error_description=current_action.result_description,
+                error_level=VDAError.FATAL,
+                error_references=[
+                    VDAErrorReference(reference_key="action_id", reference_value=current_action.action_id)
+                ],
+            )
+            current_errors = self._current_state.errors
+            self._update_state({"errors": current_errors + [error]}, publish_now=True)
+            self._update_state({"errors": current_errors})
 
     # Order
 


### PR DESCRIPTION
Changes made:
- When an action is finished, the `action_states.result_description` field of the order state is updated
- When an action is failed, an error entry in the order state is created

These two behaviors are described in the VDA5050 standard ([json schemas](https://github.com/VDA5050/VDA5050/blob/main/json_schemas/state.schema) and section 6.10.6 in the `actionStates` description)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates `result_description` to finished `action_states` and adds an `errors` entry when an action fails.
> 
> - **Controller (`vda5050_connector_py/vda5050_controller.py`)**:
>   - **Action state updates**:
>     - Extend `_update_action_status(action_id, action_status, result_description="")`; when status is `VDACurrentAction.FINISHED`, set `action_state.result_description`.
>     - Pass `result_description` in callbacks (`_get_state_from_adapter_callback`, `_process_vda_action_result_callback`).
>   - **Error reporting**:
>     - Add `ActionErrors.ACTION_FAILED`.
>     - On `VDACurrentAction.FAILED`, append `VDAError` with `error_type="actionFailed"`, `error_description` from `result_description`, and `errorReferences` with `action_id` (publish then revert).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0efc878f8c096117965749f52a56b5d30e8a1667. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->