### PR TITLE
Fix VDA5050 versioning in ROS2 topic

### DIFF
--- a/vda5050_connector/config/connector_example.yaml
+++ b/vda5050_connector/config/connector_example.yaml
@@ -1,20 +1,21 @@
 mqtt_bridge:
   ros__parameters:
+    vda5050_protocol_version: "2.0.0"
     mqtt_address: "localhost"
     mqtt_port: 1883
     mqtt_username: ""
     mqtt_password: ""
-    manufacturer_name: "robots"
-    serial_number: "robot_1"
+    manufacturer_name: "agilex"
+    serial_number: "e42069"
 
 controller:
   ros__parameters:
-    robot_name: "robot_1"
-    manufacturer_name: "robots"
-    serial_number: "robot_1"
+    robot_name: "agv_franklin"
+    manufacturer_name: "agilex"
+    serial_number: "e42069"
 
 adapter:
   ros__parameters:
-    robot_name: "robot_1"
-    manufacturer_name: "robots"
-    serial_number: "robot_1"
+    robot_name: "agv_franklin"
+    manufacturer_name: "agilex"
+    serial_number: "e42069"

--- a/vda5050_connector/launch/mqtt_bridge.launch.py
+++ b/vda5050_connector/launch/mqtt_bridge.launch.py
@@ -80,6 +80,7 @@ def generate_launch_description():
         namespace=namespace,
         name="mqtt_bridge",
         parameters=[configured_params],
+        arguments=['--ros-args', '--log-level', "debug"]
     )
 
     # Create the launch description and populate

--- a/vda5050_connector/vda5050_connector_py/mqtt_bridge.py
+++ b/vda5050_connector/vda5050_connector_py/mqtt_bridge.py
@@ -238,6 +238,9 @@ class MQTTBridge(Node):
 
         self.vda5050_version = read_str_parameter(self, "vda5050_protocol_version", "2.0.0")
         self.vda5050_version_alias = generate_vda5050_topic_alias(self.vda5050_version)
+        
+        # DEBUG: Log the version being used
+        self.get_logger().info(f"VDA5050 Protocol Version: {self.vda5050_version} (alias: {self.vda5050_version_alias})")
 
         self._manufacturer_name = read_str_parameter(
             self, "manufacturer_name", "robots"
@@ -389,7 +392,8 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="state",
-                interface_name=self._interface_name
+                interface_name=self._interface_name,
+                major_version=self.vda5050_version_alias
             ),
             callback=self._publish_state,
             qos_profile=10,
@@ -401,7 +405,8 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="connection",
-                interface_name=self._interface_name
+                interface_name=self._interface_name,
+                major_version=self.vda5050_version_alias
             ),
             callback=self._publish_connection,
             qos_profile=10,
@@ -413,7 +418,8 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="visualization",
-                interface_name=self._interface_name
+                interface_name=self._interface_name,
+                major_version=self.vda5050_version_alias
             ),
             callback=self._publish_visualization,
             qos_profile=10,
@@ -425,7 +431,8 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="order",
-                interface_name=self._interface_name
+                interface_name=self._interface_name,
+                major_version=self.vda5050_version_alias
             ),
             qos_profile=10,
         )
@@ -436,7 +443,8 @@ class MQTTBridge(Node):
                 manufacturer=self._manufacturer_name,
                 serial_number=self._serial_number,
                 topic="instantActions",
-                interface_name=self._interface_name
+                interface_name=self._interface_name,
+                major_version=self.vda5050_version_alias
             ),
             qos_profile=10,
         )
@@ -494,6 +502,14 @@ class MQTTBridge(Node):
 
         """
         json_msg = convert_ros_message_to_json(msg)
+        
+        # WORKAROUND: Remove 'informations' field for OpenTCS compatibility
+        # OpenTCS v2.0 driver doesn't accept this field even though it's in VDA5050 v2.0 spec
+        json_dict = json.loads(json_msg)
+        if 'informations' in json_dict:
+            del json_dict['informations']
+        json_msg = json.dumps(json_dict)
+        
         self.logger.debug(f"Publishing MQTT message to topic {topic}: {json_msg}")
         self.mqtt_client.publish(topic, json_msg)
 


### PR DESCRIPTION
As-is it seems the vda5050_connector always default to 'v1' in generating ROS2/MQTT topics. Fixed. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures topics use the configured VDA5050 version alias and removes the 'informations' field from published messages; adds config param and debug logging.
> 
> - **VDA5050 versioning**:
>   - Read `vda5050_protocol_version` (default `"2.0.0"`) and derive alias via `generate_vda5050_topic_alias`.
>   - Pass `major_version` to all ROS2 topics in `mqtt_bridge.py` (`state`, `connection`, `visualization`, `order`, `instantActions`).
>   - Log chosen protocol version and alias at startup.
> - **MQTT publish behavior**:
>   - In `_publish_to_topic`, remove `informations` field from JSON before publishing for OpenTCS v2.0 compatibility.
>   - Add debug logs for published messages/topics.
> - **Config/Launch**:
>   - Add `vda5050_protocol_version` to `config/connector_example.yaml`; update example identifiers.
>   - In `mqtt_bridge.launch.py`, set node arguments to `--ros-args --log-level debug`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41663d3a5d17bbeb327afe1f9c2796879fcbc2c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->