### PR TITLE
Clear errors related to an order on cancel request

### DIFF
--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -1311,11 +1311,23 @@ class VDA5050Controller(Node):
             self._navigate_to_node_goal_handle.cancel_goal_async()
             return
 
+        # Delete remaining node / edge states / clear errors related to the order
+        errors = [
+            error
+            for error in self._current_state.errors
+            if error.error_type not in [e.value for e in OrderRejectErrors]
+        ]
+
         # Once all the VDA actions and navigation goal requests have finished,
         # the cancel order will be mark as finished
-
-        # Delete remaining node / edge states
-        self._update_state({"new_base_request": False, "node_states": [], "edge_states": []})
+        self._update_state(
+            {
+                "errors": errors,
+                "new_base_request": False,
+                "node_states": [],
+                "edge_states": [],
+            }
+        )
         self._update_action_status(self._cancel_action.action_id, VDACurrentAction.FINISHED)
         self._current_order = VDAOrder(order_id="-1")
         self._cancel_action = None


### PR DESCRIPTION
Hi, 
I'm using this package and a noticed that if an order is on error state, when canceled the errors are still reported on vehicle state. 
The errors are only cleared when a new order is accepted. 
With this PR the errors will also be cleared when a task is canceled.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves `cancelOrder` handling to avoid lingering order errors after cancellation.
> 
> - In `vda5050_controller.py::_cancel_order`, now filters out `errors` with types in `OrderRejectErrors` and updates state with the cleaned list along with clearing `node_states`, `edge_states`, and `new_base_request`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 159ba32292e01eadfadfcaed6e57a2dd8d2edbc0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->