### PR TITLE
Fix/clear current node goal ab

### DIFF
--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -1348,6 +1348,7 @@ class VDA5050Controller(Node):
         self._update_action_status(self._cancel_action.action_id, VDACurrentAction.FINISHED)
         self._current_order = VDAOrder(order_id="-1")
         self._cancel_action = None
+        self._current_node_goal = None
         self._current_node_actions = []
 
         self.logger.info("Finished executing cancelOrder.")

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -1496,7 +1496,7 @@ class VDA5050Controller(Node):
 
             self.send_adapter_navigate_to_node(edge=next_edge, node=next_node)
         else:
-            self.logger.error(f"{next_node} Already current goal")
+            self.logger.error(f"{next_node} Already current goal", throttle_duration_sec=5)
     # ---- Navigate to node: send goals ----
 
     def send_adapter_navigate_to_node(self, edge: VDAEdge, node: VDANode):


### PR DESCRIPTION
Before after a an order gets canceled the self._current_node_goal wasn't being set to None triggering "Already current goal" warning messages.
With this fix the current_node_goal gets cleared and also reduces the frequency of the warning messages on the log. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small state-reset and logging-only change in the order cancellation/navigation loop; low chance of behavioral impact beyond reducing spurious errors.
> 
> **Overview**
> Fixes noisy "Already current goal" errors after `cancelOrder` by clearing `self._current_node_goal` when an order cancellation completes.
> 
> Also throttles the duplicate-goal error log in `_process_next_edge` (adds `throttle_duration_sec=5`) to reduce repeated log spam when the next node matches the current goal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4acc5b2459e2e71ecc7ede44afcfe653d5e75d82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->