### PR TITLE
convert refKey value to camelCase for MQTT msg

### DIFF
--- a/vda5050_connector/vda5050_connector_py/utils.py
+++ b/vda5050_connector/vda5050_connector_py/utils.py
@@ -198,6 +198,10 @@ def json_snake_to_camel_case(s):
             if new_key != key:
                 obj[new_key] = obj[key]
                 del obj[key]
+        # referenceKey value must be camelCase per VDA5050 standard,
+        # but is stored as snake_case in the ROS2 message
+        if "referenceKey" in obj:
+            obj["referenceKey"] = to_camel_case(obj["referenceKey"])
         return obj
 
     return json.loads(s, object_hook=camel_case_dict)

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -1243,7 +1243,7 @@ class VDA5050Controller(Node):
         if error == OrderRejectErrors.ORDER_UPDATE_ERROR:
             # On orderUpdateError send orderUpdateId and orderId as reference
 
-            # TODO: Question: camelCase or snakeCase (order_id or orderId)
+            # reference_key value is snake_case for ROS2; camelCase conversion for MQTT is done in mqtt_bridge
             error_references.append(
                 VDAErrorReference(reference_key="order_id", reference_value=order.order_id)
             )


### PR DESCRIPTION
`errorReferences.referenceKey` values were sent in snake_case in the MQTT state message, instead of camelCase as required by the VDA5050 standard