### PR TITLE
[fix] vda5050_connector: handle SIGINT gracefully

### DIFF
--- a/vda5050_connector/scripts/mqtt_bridge.py
+++ b/vda5050_connector/scripts/mqtt_bridge.py
@@ -51,7 +51,7 @@ def main(args=None):
         # Destroy the node explicitly
         # (optional - Done automatically when node is garbage collected)
         mqtt_bridge.destroy_node()
-        rclpy.shutdown()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":

--- a/vda5050_connector/scripts/vda5050_controller.py
+++ b/vda5050_connector/scripts/vda5050_controller.py
@@ -45,10 +45,13 @@ def main(args=None):
     executor = MultiThreadedExecutor()
     executor.add_node(vda5050_controller_node)
 
-    executor.spin()
-
-    vda5050_controller_node.destroy_node()
-    rclpy.shutdown()
+    try:
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        vda5050_controller_node.destroy_node()
+        rclpy.try_shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
On SIGINT, both nodes crashed with errors instead of exiting cleanly:

- vda5050_controller.py: `executor.spin()` raised an unhandled KeyboardInterrupt, causing a traceback and preventing proper node cleanup.
- mqtt_bridge.py: `rclpy.shutdown()` was called after the context was already shut down by the signal handler, raising a RCLError exception.