### PR TITLE
[fix] vda5050_connector: exclude instant actions from active order check

### DIFF
--- a/vda5050_connector/test/test_vda5050_controller.py
+++ b/vda5050_connector/test/test_vda5050_controller.py
@@ -47,6 +47,8 @@ from vda5050_msgs.msg import Edge
 from vda5050_msgs.msg import NodePosition
 from vda5050_msgs.msg import Action
 from vda5050_msgs.msg import ActionParameter
+from vda5050_msgs.msg import InstantActions
+from vda5050_msgs.msg import CurrentAction
 
 
 def get_order_new(order_id=str(uuid4()), order_update_id=0):
@@ -667,3 +669,96 @@ def test_vda5050_controller_node_reject_order(
         error=OrderRejectErrors.ORDER_UPDATE_ERROR,
         description="New update id 0 lower than old update id 1",
     )
+
+
+def get_instant_actions(*action_types):
+    """Build an InstantActions message with one action per given action_type."""
+    return InstantActions(
+        header_id=0,
+        timestamp=get_vda5050_ts(),
+        version="1.1.1",
+        manufacturer="MANUFACTURER",
+        serial_number="SERIAL_NUMBER",
+        actions=[
+            Action(
+                action_type=action_type,
+                action_id=str(uuid4()),
+                action_description=action_type,
+                blocking_type="NONE",
+            )
+            for action_type in action_types
+        ],
+    )
+
+
+def test_instant_action_does_not_block_active_order_check(
+    mocker,
+    adapter_node,
+    action_server_nav_to_node,
+    action_server_process_vda_action,
+    service_get_state,
+    service_supported_actions,
+):
+    node = VDA5050Controller()
+    node.logger.set_level(LoggingSeverity.DEBUG)
+
+    # No order and no instant actions: no active order
+    assert not node._has_current_order()
+
+    # The instant action is now WAITING/INITIALIZING — _has_current_order must still be False
+    instant_actions = get_instant_actions("startPause")
+    node.process_instant_actions(instant_actions)
+    assert not node._has_current_order()
+
+    # Manually move the instant action to RUNNING to cover that state too
+    action_id = instant_actions.actions[0].action_id
+    node._update_action_status(action_id, CurrentAction.RUNNING)
+    assert not node._has_current_order()
+
+    # Once it finishes it should still return False (no nodes/edges)
+    node._update_action_status(action_id, CurrentAction.FINISHED)
+    assert not node._has_current_order()
+
+
+def test_instant_action_ids_tracked_on_process_instant_actions(
+    mocker,
+    adapter_node,
+    action_server_nav_to_node,
+    action_server_process_vda_action,
+    service_get_state,
+    service_supported_actions,
+):
+    node = VDA5050Controller()
+
+    instant_actions = get_instant_actions("startPause", "stopPause")
+    node.process_instant_actions(instant_actions)
+
+    for action in instant_actions.actions:
+        assert action.action_id in node._instant_action_ids
+
+
+def test_order_action_still_blocks_active_order_check(
+    mocker,
+    adapter_node,
+    action_server_nav_to_node,
+    action_server_process_vda_action,
+    service_get_state,
+    service_supported_actions,
+):
+    node = VDA5050Controller()
+    node.logger.set_level(LoggingSeverity.DEBUG)
+
+    # Process an order that contains a node action
+    [base_order, _] = get_stitch_orders()
+    node.process_order(base_order)
+
+    rclpy.spin_once(node)
+    rclpy.spin_once(adapter_node)
+
+    # The order has running node/edge states — active order must be True
+    assert node._has_current_order()
+
+    # Layering an instant action on top must not change the result
+    instant_actions = get_instant_actions("startPause")
+    node.process_instant_actions(instant_actions)
+    assert node._has_current_order()

--- a/vda5050_connector/vda5050_connector_py/vda5050_controller.py
+++ b/vda5050_connector/vda5050_connector_py/vda5050_controller.py
@@ -152,6 +152,7 @@ class VDA5050Controller(Node):
         self._read_parameters()
 
         self._cancel_action = None
+        self._instant_action_ids = set()
         self._current_node_actions = []
         self._current_node_goal = None
         self._current_order = VDAOrder(order_id="-1")
@@ -714,13 +715,14 @@ class VDA5050Controller(Node):
                 f"Processing action '{action.action_id}' of type '{action.action_type}'"
             )
 
-            # Add action to action_states
+            # Add action to action_states and track it as an instant action
             action_state = VDACurrentAction(
                 action_id=action.action_id,
                 action_type=action.action_type,
                 action_description=action.action_description,
                 action_status=VDACurrentAction.WAITING,
             )
+            self._instant_action_ids.add(action.action_id)
             self._update_state(
                 {"action_states": self._current_state.action_states + [action_state]}
             )
@@ -982,6 +984,7 @@ class VDA5050Controller(Node):
                 not in [VDACurrentAction.FINISHED, VDACurrentAction.FAILED]
                 for action_state in self._current_state.action_states
                 if action_state.action_id != action_id_cancel
+                and action_state.action_id not in self._instant_action_ids
             ]
         )
 
@@ -1002,6 +1005,7 @@ class VDA5050Controller(Node):
                 action_state
                 for action_state in self._current_state.action_states
                 if action_state.action_id != action_id_cancel and
+                action_state.action_id not in self._instant_action_ids and
                 action_state.action_status not in [
                     VDACurrentAction.FINISHED, VDACurrentAction.FAILED
                 ]


### PR DESCRIPTION
**Issue:** A standalone `instantAction` with status RUNNING caused `_has_current_order()` to return True even with empty `node_states`/`edge_states`, incorrectly blocking new order acceptance with "order rejected because already an active running order".

**Fix:** Track instant action IDs and exclude them from the running-actions check. This backports the intent of VDA5050 v3's explicit `instantActionStates`/`actionStates` separation to the current v2 implementation.