### PR TITLE
Fix EulerZYX call for Humble PyKDL compatibility

### DIFF
--- a/massrobotics_amr_sender_py/massrobotics_amr_sender/__init__.py
+++ b/massrobotics_amr_sender_py/massrobotics_amr_sender/__init__.py
@@ -282,7 +282,7 @@ class MassRoboticsAMRInteropNode(Node):
             x=twist.linear.x, y=twist.linear.y, z=twist.linear.z
         ).Norm()
         quat = PyKDL.Rotation.EulerZYX(
-            Alfa=twist.angular.z, Beta=twist.angular.y, Gamma=twist.angular.x
+            twist.angular.z, twist.angular.y, twist.angular.x
         ).GetQuaternion()
 
         self.mass_status_report.data[param_name] = {


### PR DESCRIPTION
Humble's PyKDL accepts positional args only, so the keyword form (Alfa/Beta/Gamma) crashes the sender on every TwistStamped message. Use positional args — behavior-identical and still works on Foxy.

Relates to #56 (Humble support).