### PR TITLE
Remove f-prefix from f-strings without placeholders

### DIFF
--- a/massrobotics_amr_sender_py/massrobotics_amr_sender/__init__.py
+++ b/massrobotics_amr_sender_py/massrobotics_amr_sender/__init__.py
@@ -133,7 +133,7 @@ class MassRoboticsAMRInteropNode(Node):
                 loop.run_until_complete(
                     self._async_send_report(self.mass_status_report)
                 )
-                self.logger.debug(f"Status report sent. Waiting ...")
+                self.logger.debug("Status report sent. Waiting ...")
                 sleep(STATUS_REPORT_INTERVAL)
 
         loop.create_task(send_status())
@@ -182,7 +182,7 @@ class MassRoboticsAMRInteropNode(Node):
             mass_object (:obj:`MassObject`): Identity or Status report
 
         """
-        self.logger.debug(f"Validating schema MassRobotics object schema")
+        self.logger.debug("Validating schema MassRobotics object schema")
         try:
             mass_object.validate_schema()
         except jsonschema_exc.ValidationError as ex:


### PR DESCRIPTION
Two debug logs used f-strings with no placeholders (`__init__.py` L136, L185), tripping flake8 F541 and failing `test_flake8`. Dropping the `f` prefix makes the lint test pass — verified via `colcon test` on Humble (22 tests, 0 failures).